### PR TITLE
Update HUGO_VERSION to 0.150.0 in production and deploy-preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,10 +3,10 @@
   command = "hugo --gc --minify"
 
 [context.production.environment]
-  HUGO_VERSION = "0.132.1"
+  HUGO_VERSION = "0.150.0"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.132.1"
+  HUGO_VERSION = "0.150.0"
 
 [context.deploy-preview]
   command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,10 +3,10 @@
   command = "hugo --gc --minify"
 
 [context.production.environment]
-  HUGO_VERSION = "0.150.0"
+  HUGO_VERSION = "0.134.0"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.150.0"
+  HUGO_VERSION = "0.134.0"
 
 [context.deploy-preview]
   command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
This pull request updates the Hugo version used in the Netlify deployment configuration to ensure compatibility with the latest features and bug fixes.

Deployment configuration update:

* Upgraded the `HUGO_VERSION` from `0.132.1` to `0.150.0` for both production and deploy-preview environments in `netlify.toml`.